### PR TITLE
fix: Resolve multiple issues reported by user

### DIFF
--- a/backend/db/init.sql
+++ b/backend/db/init.sql
@@ -11,7 +11,7 @@ CREATE TABLE Server (
   location VARCHAR(255) DEFAULT 'Unknown',
   ping INT DEFAULT 0,
   status VARCHAR(50) DEFAULT 'online'
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE server_pricing (
   server_id INT PRIMARY KEY,
@@ -22,7 +22,7 @@ CREATE TABLE server_pricing (
   reseller_2ip INT DEFAULT 215,
   reseller_4ip INT DEFAULT 300,
   FOREIGN KEY (server_id) REFERENCES Server(id) ON DELETE CASCADE
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE users (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -44,7 +44,7 @@ CREATE TABLE users (
   total_transaksi INT DEFAULT 0,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE admins (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -53,7 +53,7 @@ CREATE TABLE admins (
   password_hash VARCHAR(255) NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE vpn_account (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -82,7 +82,7 @@ CREATE TABLE vpn_account (
   trojan_grpc_link TEXT,
   FOREIGN KEY (server_id) REFERENCES Server(id) ON DELETE CASCADE,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE balance_transactions (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -96,7 +96,7 @@ CREATE TABLE balance_transactions (
   balance_after INT NOT NULL,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE pricing_config (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -106,7 +106,7 @@ CREATE TABLE pricing_config (
   is_active TINYINT(1) DEFAULT 1,
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE topup_transactions (
   id INT PRIMARY KEY AUTO_INCREMENT,
@@ -124,9 +124,9 @@ CREATE TABLE topup_transactions (
   created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
-CREATE TABLE android_metadata (locale VARCHAR(255));
+CREATE TABLE android_metadata (locale VARCHAR(255)) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE messages (
     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -138,7 +138,7 @@ CREATE TABLE messages (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     created_by_admin_id INT NOT NULL,
     FOREIGN KEY (created_by_admin_id) REFERENCES admins(id) ON DELETE CASCADE
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE message_reads (
     message_id INT NOT NULL,
@@ -147,7 +147,7 @@ CREATE TABLE message_reads (
     PRIMARY KEY (message_id, user_id),
     FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 CREATE TABLE bug_hosts (
     id INT PRIMARY KEY AUTO_INCREMENT,
@@ -156,7 +156,7 @@ CREATE TABLE bug_hosts (
     is_wildcard TINYINT(1) NOT NULL DEFAULT 0,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-);
+) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 INSERT INTO pricing_config (ip_limit, daily_price, description) VALUES
 (1, 330, '1 IP - Satu perangkat'),

--- a/backend/routes/getServers.js
+++ b/backend/routes/getServers.js
@@ -66,24 +66,16 @@ router.get('/', async (req, res) => {
         status: finalStatus,
         protocols: (row.protocols || 'ssh,vmess,vless,trojan').split(','),
         ping: currentPing,
-        users: row.active_accounts_count
+        users: row.active_accounts_count,
+        batas_create_akun: row.batas_create_akun,
+        total_create_akun: row.total_create_akun
       };
-
-      if (userRole === 'member') {
-        return {
-          ...baseData,
-          batas_create_akun: row.batas_create_akun,
-          total_create_akun: row.active_accounts_count
-        };
-      }
 
       if (userRole === 'admin') {
         return {
           ...baseData,
           domain: row.domain,
           auth: row.auth,
-          batas_create_akun: row.batas_create_akun,
-          total_create_akun: row.active_accounts_count,
           originalStatus: row.status
         };
       }

--- a/backend/routes/renewAccount.js
+++ b/backend/routes/renewAccount.js
@@ -13,7 +13,7 @@ async function renewAccountOnServer(protocol, username, exp, quota, limitip, ser
 
   const port = server.domain.includes("-upc.") ? 8443 : 5888;
   const renewalEndpoints = {
-    ssh: `renewssh?user=${username}&exp=${exp}&iplimit=${limitip}`,
+    ssh: `renewssh?user=${username}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
     vmess: `renewvmess?user=${username}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
     vless: `renewvless?user=${username}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
     trojan: `renewtrojan?user=${username}&exp=${exp}&quota=${quota}&iplimit=${limitip}`
@@ -64,11 +64,38 @@ router.post('/', authenticateToken, async (req, res) => {
       'account_renewal', accountId, connection
     );
 
-    const renewResult = await renewAccountOnServer(protocol, username, duration, quota, ip_limit, account);
+    let exp_param = duration;
+    if (protocol === 'ssh') {
+        const currentExpiry = new Date(account.expired_date);
+        const now = new Date();
+        const startDate = currentExpiry > now ? currentExpiry : now;
+
+        const newExpiry = new Date(startDate);
+        newExpiry.setDate(newExpiry.getDate() + duration);
+
+        // Format to YYYY-MM-DD
+        exp_param = newExpiry.toISOString().split('T')[0];
+    }
+
+    const renewResult = await renewAccountOnServer(protocol, username, exp_param, quota, ip_limit, account);
+
+    let newExpiredDate;
+    if (protocol === 'ssh') {
+      // For SSH, the external server might return a weird format, so we trust our own calculation
+      const currentExpiry = new Date(account.expired_date);
+      const now = new Date();
+      const startDate = currentExpiry > now ? currentExpiry : now;
+
+      const finalNewExpiry = new Date(startDate);
+      finalNewExpiry.setDate(finalNewExpiry.getDate() + duration);
+      newExpiredDate = finalNewExpiry;
+    } else {
+      newExpiredDate = renewResult.data.expired;
+    }
 
     await connection.query(
       'UPDATE vpn_account SET expired_date = ?, duration = ? WHERE id = ?',
-      [renewResult.data.expired, duration, accountId]
+      [newExpiredDate, duration, accountId]
     );
 
     await connection.commit();
@@ -87,7 +114,7 @@ router.post('/', authenticateToken, async (req, res) => {
       success: true,
       message: renewResult.message,
       data: {
-        expired_date: renewResult.data.expired,
+        expired_date: newExpiredDate, // Send back the correct date
         duration, quota, ip_limit, cost: renewalCost, userRole, balance_deducted: renewalCost
       }
     });


### PR DESCRIPTION
This commit addresses three separate issues:

1.  **Emoji Support in Database:**
    - The `init.sql` schema has been updated to use the `utf8mb4` character set and `utf8mb4_unicode_ci` collation for all tables.
    - This resolves a bug where creating a server with an emoji in the name would fail due to incorrect database encoding.

2.  **Server Account Limit Display:**
    - The API endpoint at `backend/routes/getServers.js` has been modified to always include the `batas_create_akun` (maximum account limit) in the server data response.
    - This fixes a UI bug where the indicator for active/max accounts was not displaying correctly (e.g., showing `1/` instead of `1/5`).

3.  **SSH Account Renewal Failure:**
    - The logic in `backend/routes/renewAccount.js` has been significantly improved to handle SSH account renewals correctly.
    - It now calculates the new expiration date on the backend in `YYYY-MM-DD` format to prevent the external API from misinterpreting the value.
    - It also uses this self-calculated date to update the local database, ensuring data integrity and fixing errors related to incorrect datetime values.