### PR TITLE
Fix: Replace session MemoryStore with MySQLStore

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "dayjs": "^1.11.13",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-mysql-session": "^3.0.0",
         "express-session": "^1.17.3",
         "jsonwebtoken": "^9.0.0",
         "mysql2": "^3.10.0",
@@ -595,6 +596,79 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-mysql-session": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-3.0.3.tgz",
+      "integrity": "sha512-sEYrzFrOs3er+Ie/uk1dt93qz4AQ9SU1mpJJ0HPs0MJ4t4hE9AcDRNq0sZQUwy2F/SbXusBt1E5+FY6KzSqXNg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.4",
+        "mysql2": "3.10.2"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/express-mysql-session/node_modules/mysql2": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/express-session": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "nodemailer": "^6.9.8",
     "uuid": "^9.0.1",
     "node-cron": "^3.0.0",
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "express-mysql-session": "^3.0.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ dotenv.config({ path: path.join(__dirname, '.env') });
 const express = require("express");
 const cors = require("cors");
 const session = require("express-session");
+const MySQLStore = require('express-mysql-session')(session);
 const passport = require("passport");
 const { authenticateToken } = require("./middleware/auth");
 const { verifyAdminToken } = require("./routes/adminAuth");
@@ -17,11 +18,35 @@ const PORT = process.env.PORT || 3001;
 app.use(cors());
 app.use(express.json());
 
+// Database connection options for session store
+const dbOptions = {
+  host: process.env.DB_HOST,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_DATABASE,
+};
+
+// Session store configuration
+const sessionStore = new MySQLStore({
+  expiration: 86400000, // 24 hours
+  createDatabaseTable: true,
+  schema: {
+    tableName: 'sessions',
+    columnNames: {
+      session_id: 'session_id',
+      expires: 'expires',
+      data: 'data'
+    }
+  },
+  ...dbOptions // Pass connection options directly
+});
+
 // Session configuration for Google OAuth
 app.use(session({
   secret: process.env.SESSION_SECRET || 'your-default-session-secret-key',
   resave: false,
   saveUninitialized: false,
+  store: sessionStore, // Use the MySQL session store
   cookie: { 
     secure: process.env.NODE_ENV === 'production', 
     maxAge: 24 * 60 * 60 * 1000 // 24 hours


### PR DESCRIPTION
The application was using the default express-session MemoryStore, which is not suitable for production as it can cause memory leaks and does not scale beyond a single process. This was causing a warning on server startup.

This commit replaces the MemoryStore with `express-mysql-session` to persist session data in the MySQL database. The session store is now configured to use the existing database connection details from the environment variables, resolving the warning and providing a robust, production-ready session management solution.