### PR TITLE
Fix XL scheduled purchase status update bug

### DIFF
--- a/backend/services/xlTransactionChecker.js
+++ b/backend/services/xlTransactionChecker.js
@@ -64,10 +64,11 @@ const checkPendingTransactions = async () => {
             [trx.id]
           );
 
-          // Jika ini terkait dengan scheduled purchase, update statusnya
+          // Jika ini terkait dengan scheduled purchase, update statusnya (hanya jadwal hari ini)
+          const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Jakarta' }); // Format YYYY-MM-DD
           await pool.query(
-            "UPDATE xl_scheduled_purchases SET status = 'completed' WHERE user_id = ? AND phone_number = ? AND package_code = ? AND status != 'completed'",
-            [trx.user_id, trx.phone, trx.package_code]
+            "UPDATE xl_scheduled_purchases SET status = 'completed' WHERE user_id = ? AND phone_number = ? AND package_code = ? AND scheduled_date = ? AND status != 'completed'",
+            [trx.user_id, trx.phone, trx.package_code, today]
           );
 
           if (isTimeout) {
@@ -132,10 +133,11 @@ const checkPendingTransactions = async () => {
               [trx.id]
             );
 
-            // Update scheduled purchase jika ada
+            // Update scheduled purchase jika ada (hanya jadwal hari ini)
+            const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Jakarta' }); // Format YYYY-MM-DD
             await connection.query(
-              "UPDATE xl_scheduled_purchases SET status = 'failed' WHERE user_id = ? AND phone_number = ? AND package_code = ? AND status != 'failed'",
-              [trx.user_id, trx.phone, trx.package_code]
+              "UPDATE xl_scheduled_purchases SET status = 'failed' WHERE user_id = ? AND phone_number = ? AND package_code = ? AND scheduled_date = ? AND status != 'failed'",
+              [trx.user_id, trx.phone, trx.package_code, today]
             );
 
             await connection.commit();


### PR DESCRIPTION
### Perbaikan Bug Jadwal Pembelian XL
Menambahkan parameter `scheduled_date = ?` ke dalam query update pada file `backend/services/xlTransactionChecker.js` untuk memastikan bahwa pembaruan status jadwal menjadi 'completed' atau 'failed' hanya terjadi untuk jadwal pembelian hari ini (berdasarkan waktu Asia/Jakarta). Sebelumnya, sistem akan memperbarui **seluruh jadwal** yang aktif untuk pengguna dengan nomor dan paket yang sama, mengabaikan jadwal di masa depan.
Fitur retry harian (jam 01:00 dan 03:00) yang ada di `scheduledPurchaseService.js` tetap berfungsi tanpa perubahan karena fitur tersebut sudah melakukan pemfilteran berdasarkan tanggal hari ini saat memproses jadwal berstatus 'failed'.

---
*PR created automatically by Jules for task [1724817230459257534](https://jules.google.com/task/1724817230459257534) started by @KedaiVPN*