### PR TITLE
feat: add admin server accounts info feature

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,4 +1,8 @@
 const express = require('express');
+const axios = require("axios");
+const dayjs = require("dayjs");
+const BalanceService = require("../services/balanceService");
+const TelegramService = require("../services/telegramService");
 const pool = require('../db/connection');
 const router = express.Router();
 const { generateTokenForUser } = require('../middleware/auth');
@@ -407,4 +411,228 @@ router.delete('/scheduled-purchases/:scheduleId', async (req, res) => {
 });
 
 
+// Get accounts for a specific server
+router.get('/servers/:id/accounts', async (req, res) => {
+  const serverId = req.params.id;
+  try {
+    const query = `
+      SELECT
+        v.*,
+        u.username as owner_username,
+        u.email as owner_email,
+        DATE_FORMAT(v.expired_date, '%Y-%m-%d %H:%i') as expired_date_formatted
+      FROM vpn_account v
+      LEFT JOIN users u ON v.user_id = u.id
+      WHERE v.server_id = ?
+      ORDER BY v.created_at DESC
+    `;
+    const [rows] = await pool.query(query, [serverId]);
+    res.json(rows);
+  } catch (err) {
+    console.error('Error fetching server accounts:', err);
+    res.status(500).json({ error: "Failed to fetch server accounts" });
+  }
+});
+
+
+
+
+
+
+async function renewAccountOnServerForAdmin(protocol, identifier, exp, quota, limitip, server) {
+  if (protocol !== 'zivpn' && (/\s/.test(identifier) || /[^a-zA-Z0-9]/.test(identifier))) {
+    throw new Error('❌ Username tidak valid.');
+  }
+
+  const port = server.domain.includes("-upc.") ? 8443 : 5888;
+  const renewalEndpoints = {
+    ssh: `renewssh?user=${identifier}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
+    vmess: `renewvmess?user=${identifier}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
+    vless: `renewvless?user=${identifier}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
+    trojan: `renewtrojan?user=${identifier}&exp=${exp}&quota=${quota}&iplimit=${limitip}`,
+    zivpn: `renew/zivpn?password=${identifier}&exp=${exp}`
+  };
+
+  const endpoint = renewalEndpoints[protocol];
+  const url = `http://${server.domain}:${port}/${endpoint}&auth=${server.auth}`;
+  const response = await axios.get(url);
+
+  if (response.data.status !== "success") {
+    throw new Error(`❌ Terjadi kesalahan: ${response.data.message}`);
+  }
+  return response.data;
+}
+
+const deleteEndpointMap = {
+  ssh: 'deletessh',
+  vmess: 'deletevmess',
+  vless: 'deletevless',
+  trojan: 'deletetrojan',
+  zivpn: 'delete/zivpn'
+};
+
+// Admin endpoint to renew VPN account using the owner's balance
+router.post('/accounts/:accountId/renew', async (req, res) => {
+  const { accountId } = req.params;
+  const { duration } = req.body;
+  const connection = await pool.getConnection();
+
+  try {
+    await connection.beginTransaction();
+
+    const [accounts] = await connection.query(
+      `SELECT va.*, s.id as server_id, s.domain, s.auth, s.nama_server, u.username as owner_username
+       FROM vpn_account va
+       LEFT JOIN Server s ON va.server_id = s.id
+       LEFT JOIN users u ON va.user_id = u.id
+       WHERE va.id = ?`,
+      [accountId]
+    );
+    const account = accounts[0];
+
+    if (!account) {
+      throw new Error('Account not found');
+    }
+
+    const userId = account.user_id; // Owner's user ID
+    const { username, password, protocol, server_id, quota, ip_limit } = account;
+
+    // Calculate cost based on owner's role
+    const userRole = await BalanceService.getUserRole(userId);
+    const renewalCost = await BalanceService.calculateServerAccountCost(ip_limit, duration, userRole, server_id);
+
+    // Validate owner's balance
+    await BalanceService.validateSufficientBalance(userId, renewalCost, connection);
+
+    // Deduct from owner's balance
+    await BalanceService.deductBalance(
+      userId, renewalCost, `Perpanjang akun ${protocol.toUpperCase()} oleh Admin - ${username} (${duration} hari)`,
+      'account_renewal', accountId, connection
+    );
+
+    let exp_param = duration;
+    if (protocol === 'ssh') {
+        const currentExpiry = new Date(account.expired_date);
+        const now = new Date();
+        const startDate = currentExpiry > now ? currentExpiry : now;
+        const newExpiry = new Date(startDate);
+        newExpiry.setDate(newExpiry.getDate() + duration);
+        exp_param = newExpiry.toISOString().split('T')[0];
+    }
+
+    const identifier = protocol === 'zivpn' ? password : username;
+    const renewResult = await renewAccountOnServerForAdmin(protocol, identifier, exp_param, quota, ip_limit, account);
+
+    let newExpiredDate;
+    if (protocol === 'ssh' || protocol === 'zivpn') {
+      const currentExpiry = new Date(account.expired_date);
+      const now = new Date();
+      const startDate = currentExpiry > now ? currentExpiry : now;
+      const finalNewExpiry = new Date(startDate);
+      finalNewExpiry.setDate(finalNewExpiry.getDate() + duration);
+      newExpiredDate = finalNewExpiry;
+    } else {
+      newExpiredDate = renewResult.data.expired;
+    }
+
+    await connection.query(
+      'UPDATE vpn_account SET expired_date = ?, duration = ? WHERE id = ?',
+      [newExpiredDate, duration, accountId]
+    );
+
+    await connection.commit();
+    res.json({ success: true, message: renewResult.message });
+
+  } catch (error) {
+    await connection.rollback();
+    res.status(400).json({ success: false, message: error.message });
+  } finally {
+    connection.release();
+  }
+});
+
+// Admin endpoint to delete VPN account and refund to owner
+router.delete('/accounts/:accountId', async (req, res) => {
+  const { accountId } = req.params;
+  const connection = await pool.getConnection();
+
+  try {
+    await connection.beginTransaction();
+
+    const [accounts] = await connection.query(
+      `SELECT va.*, s.domain, s.auth
+       FROM vpn_account va
+       LEFT JOIN Server s ON va.server_id = s.id
+       WHERE va.id = ?`,
+      [accountId]
+    );
+    const account = accounts[0];
+    if (!account) {
+      throw new Error('❌ Akun tidak ditemukan.');
+    }
+
+    const { username, password, protocol, server_id, expired_date, ip_limit, user_id } = account;
+
+    if (!account.domain) {
+      throw new Error('❌ Server tidak ditemukan.');
+    }
+
+    const endpoint = deleteEndpointMap[protocol];
+    if (!endpoint) {
+      throw new Error('❌ Jenis akun tidak valid untuk penghapusan.');
+    }
+
+    const userRole = await BalanceService.getUserRole(user_id);
+    const port = account.domain.includes("-upc.") ? 8443 : 5888;
+
+    let apiURL;
+    if (protocol === 'zivpn') {
+      apiURL = `http://${account.domain}:${port}/delete/zivpn?password=${password}&auth=${account.auth}`;
+    } else {
+      apiURL = `http://${account.domain}:${port}/${endpoint}?user=${username}&auth=${account.auth}`;
+    }
+
+    const response = await axios.get(apiURL);
+    if (response.data.status !== 'success') {
+      throw new Error(`❌ Gagal menghapus akun di server: ${response.data.message}`);
+    }
+
+    const now = dayjs();
+    let sisaHari = Math.ceil(dayjs(expired_date).diff(now, 'millisecond') / (1000 * 60 * 60 * 24));
+    if (sisaHari < 0) sisaHari = 0;
+
+    let refundAmount = 0;
+    if (sisaHari > 0) {
+      const dailyPrice = await BalanceService.getDailyPrice(ip_limit, userRole, server_id);
+      refundAmount = dailyPrice * sisaHari;
+    }
+
+    await connection.query('DELETE FROM vpn_account WHERE id = ?', [accountId]);
+
+    if (refundAmount > 0) {
+      await BalanceService.addBalance(
+        user_id,
+        refundAmount,
+        `Refund penghapusan akun ${protocol.toUpperCase()} oleh Admin - ${username} (${sisaHari} hari, ${userRole})`,
+        'account_refund',
+        accountId,
+        connection
+      );
+    }
+
+    await connection.commit();
+
+    const roleText = userRole === 'reseller' ? ' (harga reseller)' : '';
+    res.json({
+      success: true,
+      message: `✅ Akun ${protocol.toUpperCase()} berhasil dihapus.\n🕒 Sisa hari: ${sisaHari}${refundAmount > 0 ? `\n💰 Refund ke User: Rp${refundAmount.toLocaleString('id-ID')}${roleText}` : ''}`
+    });
+
+  } catch (error) {
+    await connection.rollback();
+    res.status(400).json({ success: false, message: error.message || 'Failed to delete account' });
+  } finally {
+    connection.release();
+  }
+});
 module.exports = router;

--- a/src/components/ServerAccountsModal.tsx
+++ b/src/components/ServerAccountsModal.tsx
@@ -1,0 +1,257 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { ServerAccountData } from '@/services/adminService';
+import { adminService } from '@/services/adminService';
+import { Badge } from '@/components/ui/badge';
+import { RefreshCw, Trash2, Search } from 'lucide-react';
+import { toast } from 'sonner';
+interface ServerAccountsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  server: any;
+}
+
+export const ServerAccountsModal: React.FC<ServerAccountsModalProps> = ({
+  isOpen,
+  onClose,
+  server,
+}) => {
+  const [accounts, setAccounts] = useState<ServerAccountData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  // States for Renew Modal
+  const [isRenewModalOpen, setIsRenewModalOpen] = useState(false);
+  const [selectedAccountForRenew, setSelectedAccountForRenew] = useState<ServerAccountData | null>(null);
+  const [renewDuration, setRenewDuration] = useState<number>(30);
+  const [isRenewing, setIsRenewing] = useState(false);
+
+  // States for Delete Modal
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [selectedAccountForDelete, setSelectedAccountForDelete] = useState<ServerAccountData | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const fetchAccounts = async () => {
+    if (!server) return;
+    setIsLoading(true);
+    try {
+      const data = await adminService.getServerAccounts(server.id);
+      setAccounts(Array.isArray(data) ? data : []);
+    } catch (error) {
+      toast.error('Gagal mengambil daftar akun server.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen && server) {
+      fetchAccounts();
+    }
+  }, [isOpen, server]);
+
+  const filteredAccounts = accounts.filter(account =>
+    account.username.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    (account.owner_username && account.owner_username.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
+
+  const openRenewModal = (account: ServerAccountData) => {
+    setSelectedAccountForRenew(account);
+    setRenewDuration(30);
+    setIsRenewModalOpen(true);
+  };
+
+  const handleRenewAccount = async () => {
+    if (!selectedAccountForRenew || !renewDuration) return;
+    setIsRenewing(true);
+    try {
+      const result = await adminService.renewServerAccount(
+        selectedAccountForRenew.id,
+        renewDuration
+      );
+      toast.success(result.message || `Akun ${selectedAccountForRenew.username} berhasil diperpanjang.`);
+      setIsRenewModalOpen(false);
+      fetchAccounts();
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || 'Gagal memperpanjang akun');
+    } finally {
+      setIsRenewing(false);
+    }
+  };
+
+  const openDeleteModal = (account: ServerAccountData) => {
+    setSelectedAccountForDelete(account);
+    setIsDeleteModalOpen(true);
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!selectedAccountForDelete) return;
+    setIsDeleting(true);
+    try {
+      const result = await adminService.deleteServerAccount(selectedAccountForDelete.id);
+      toast.success(result.message || `Akun ${selectedAccountForDelete.username} berhasil dihapus.`);
+      setIsDeleteModalOpen(false);
+      fetchAccounts();
+    } catch (error: any) {
+      toast.error(error.response?.data?.message || 'Gagal menghapus akun');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+        <DialogContent className="max-w-4xl max-h-[85vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle>Informasi Akun Server: {server?.nama_server}</DialogTitle>
+            <DialogDescription>
+              Daftar semua akun VPN yang terdaftar di server ini.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex items-center gap-2 mb-4 mt-2">
+            <Search className="w-4 h-4 text-gray-500" />
+            <Input
+              placeholder="Cari username akun atau pemilik..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="max-w-sm"
+            />
+            <Button variant="outline" size="icon" onClick={fetchAccounts} disabled={isLoading}>
+              <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+            </Button>
+          </div>
+
+          <div className="flex-1 overflow-auto border rounded-md">
+            <Table>
+              <TableHeader className="bg-muted sticky top-0 z-10">
+                <TableRow>
+                  <TableHead>Pemilik</TableHead>
+                  <TableHead>Username Akun</TableHead>
+                  <TableHead>Protokol</TableHead>
+                  <TableHead>Masa Aktif</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead className="text-right">Aksi</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {isLoading ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-8">
+                      <div className="flex justify-center items-center">
+                        <RefreshCw className="w-6 h-6 animate-spin text-primary" />
+                        <span className="ml-2 text-sm text-gray-500">Memuat data...</span>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ) : filteredAccounts.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-8 text-gray-500">
+                      Tidak ada akun ditemukan.
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredAccounts.map((account) => (
+                    <TableRow key={account.id}>
+                      <TableCell>
+                        <div className="font-medium">{account.owner_username || '-'}</div>
+                        <div className="text-xs text-gray-500">{account.owner_email || '-'}</div>
+                      </TableCell>
+                      <TableCell className="font-mono text-sm">{account.username}</TableCell>
+                      <TableCell>
+                        <Badge variant="outline" className="uppercase">{account.protocol}</Badge>
+                      </TableCell>
+                      <TableCell>{account.expired_date_formatted}</TableCell>
+                      <TableCell>
+                        <Badge variant={account.status === 'active' ? 'default' : 'destructive'} >
+                          {account.status}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button size="sm" variant="outline" onClick={() => openRenewModal(account)}>
+                            <RefreshCw className="w-3 h-3 mr-1" /> Renew
+                          </Button>
+                          <Button size="sm" variant="destructive" onClick={() => openDeleteModal(account)}>
+                            <Trash2 className="w-3 h-3 mr-1" /> Hapus
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Renew Modal */}
+      <Dialog open={isRenewModalOpen} onOpenChange={setIsRenewModalOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Perpanjang Akun</DialogTitle>
+            <DialogDescription>
+              Perpanjang akun <strong>{selectedAccountForRenew?.username}</strong>.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Durasi (Hari)</label>
+              <Input
+                type="number"
+                min="1"
+                value={renewDuration}
+                onChange={(e) => setRenewDuration(parseInt(e.target.value) || 1)}
+              />
+            </div>
+            <p className="text-xs text-yellow-600">
+              *Catatan: Perpanjangan ini akan memotong saldo user sesuai harga normal/reseller.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" onClick={() => setIsRenewModalOpen(false)}>Batal</Button>
+            <Button onClick={handleRenewAccount} disabled={isRenewing}>
+              {isRenewing ? 'Memproses...' : 'Perpanjang'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Modal */}
+      <Dialog open={isDeleteModalOpen} onOpenChange={setIsDeleteModalOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Hapus Akun</DialogTitle>
+            <DialogDescription>
+              Apakah Anda yakin ingin menghapus akun <strong>{selectedAccountForDelete?.username}</strong>?
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex justify-end gap-2 mt-4">
+            <Button variant="outline" onClick={() => setIsDeleteModalOpen(false)}>Batal</Button>
+            <Button variant="destructive" onClick={handleDeleteAccount} disabled={isDeleting}>
+              {isDeleting ? 'Menghapus...' : 'Ya, Hapus'}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -26,8 +26,10 @@ import GameBrandImageManager from '@/components/GameBrandImageManager';
 import GameBannerManager from '@/components/GameBannerManager';
 import OtherProductManager from '@/components/OtherProductManager'; // Import the new component
 import PaymentGatewayManager from '@/components/PaymentGatewayManager';
+import { ServerAccountsModal } from '@/components/ServerAccountsModal';
 import { adminService } from '@/services/adminService';
 import { adminAuthService } from '@/services/adminAuthService';
+import { Info } from 'lucide-react';
 
 interface ServerData {
   id: number;
@@ -106,6 +108,10 @@ const AdminDashboard = () => {
   const [isUserModalOpen, setIsUserModalOpen] = useState(false);
   const [isUpdatingServer, setIsUpdatingServer] = useState(false);
   const [isCleaning, setIsCleaning] = useState(false);
+
+  // Server Accounts Modal state
+  const [isAccountsModalOpen, setIsAccountsModalOpen] = useState(false);
+  const [selectedServerForAccounts, setSelectedServerForAccounts] = useState<ServerData | null>(null);
 
 const form = useForm<AddServerForm>({
   defaultValues: {
@@ -795,6 +801,19 @@ if (!data.domain || !data.auth || !data.nama_server || !data.location || !data.p
                                 variant="outline"
                                 size="sm"
                                 className="w-full"
+                                onClick={() => {
+                                  setSelectedServerForAccounts(server);
+                                  setIsAccountsModalOpen(true);
+                                }}
+                              >
+                                <Info className="h-4 w-4 mr-2 text-blue-500" />
+                                Info Akun
+                              </Button>
+
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="w-full"
                                 onClick={() => handleEditServer(server)}
                               >
                                 <Edit className="h-4 w-4 mr-2" />
@@ -1209,6 +1228,16 @@ if (!data.domain || !data.auth || !data.nama_server || !data.location || !data.p
               </Form>
             </DialogContent>
           </Dialog>
+
+          {/* Server Accounts Modal */}
+          <ServerAccountsModal
+            isOpen={isAccountsModalOpen}
+            onClose={() => {
+              setIsAccountsModalOpen(false);
+              setSelectedServerForAccounts(null);
+            }}
+            server={selectedServerForAccounts}
+          />
 
           {/* Password Change Form */}
           <AdminPasswordChange />

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { adminAuthService } from "./adminAuthService";
 
 interface ServerData {
   id: number;
@@ -84,7 +85,6 @@ const adminApi = axios.create({
   }
 });
 
-import { adminAuthService } from './adminAuthService';
 
 // Add a request interceptor to inject the token
 adminApi.interceptors.request.use(
@@ -133,6 +133,18 @@ adminApi.interceptors.response.use(
 );
 
 export const adminService = {
+  getServerAccounts: async (serverId: number): Promise<ServerAccountData[]> => {
+    const response = await adminApi.get(`/servers/${serverId}/accounts`);
+    return response.data;
+  },
+  renewServerAccount: async (accountId: number, duration: number) => {
+    const response = await adminApi.post(`/accounts/${accountId}/renew`, { duration });
+    return response.data;
+  },
+  deleteServerAccount: async (accountId: number) => {
+    const response = await adminApi.delete(`/accounts/${accountId}`);
+    return response.data;
+  },
   // Get all servers
   getServers: async (): Promise<ServerData[]> => {
     try {
@@ -451,3 +463,17 @@ export const adminService = {
     }
   },
 };
+
+export interface ServerAccountData {
+  id: number;
+  user_id: number;
+  server_id: number;
+  username: string;
+  protocol: string;
+  duration: number;
+  status: string;
+  expired_date: string;
+  expired_date_formatted?: string;
+  owner_username?: string;
+  owner_email?: string;
+}


### PR DESCRIPTION
This PR introduces a new feature to the Admin Dashboard allowing administrators to view all VPN accounts registered on a specific server. An "Info Akun" button is added to each server card which opens a modal containing a searchable table of accounts. Administrators can also directly renew or delete accounts from this modal. The system is designed to securely identify the original owner of each account and apply the balance cost or refund appropriately when renewed or deleted by an admin.

---
*PR created automatically by Jules for task [15376195662793099490](https://jules.google.com/task/15376195662793099490) started by @KedaiVPN*