### PR TITLE
feat(admin): Add search by phone number and display phone in user management

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -158,7 +158,7 @@ router.get('/users', async (req, res) => {
     const { search, withScheduled } = req.query;
     let query = `
       SELECT
-        u.id, u.username, u.email, u.balance, u.is_locked, u.role, u.created_at,
+        u.id, u.username, u.email, u.phone_number, u.balance, u.is_locked, u.role, u.created_at,
         COALESCE(t.transaction_count, 0) as transaction_count
       FROM users u
       LEFT JOIN (
@@ -171,8 +171,8 @@ router.get('/users', async (req, res) => {
     const whereClauses = [];
 
     if (search) {
-      whereClauses.push('u.username LIKE ?');
-      params.push(`%${search}%`);
+      whereClauses.push('(u.username LIKE ? OR u.email LIKE ? OR u.phone_number = ?)');
+      params.push(`%${search}%`, `%${search}%`, search);
     }
 
     if (withScheduled === 'true') {

--- a/src/components/UserActionModal.tsx
+++ b/src/components/UserActionModal.tsx
@@ -8,7 +8,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { Plus, Minus, Lock, Unlock, User, Mail, Calendar, CreditCard } from 'lucide-react';
+import { Plus, Minus, Lock, Unlock, User, Mail, Calendar, CreditCard, Phone } from 'lucide-react';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { adminService } from '@/services/adminService';
@@ -18,6 +18,7 @@ interface UserData {
   id: number;
   username: string;
   email: string;
+  phone_number: string | null;
   balance: number;
   is_locked: boolean;
   role: 'member' | 'reseller';
@@ -204,6 +205,10 @@ const formatCurrency = (amount: number) => {
                 <div className="flex items-center gap-2">
                   <Mail className="h-4 w-4 text-muted-foreground" />
                   <span className="text-sm text-muted-foreground break-all">{user.email}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Phone className="h-4 w-4 text-muted-foreground" />
+                  <span className="text-sm text-muted-foreground">{user.phone_number || '-'}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Calendar className="h-4 w-4 text-muted-foreground" />

--- a/src/components/UserManagementTable.tsx
+++ b/src/components/UserManagementTable.tsx
@@ -11,6 +11,7 @@ interface UserData {
   id: number;
   username: string;
   email: string;
+  phone_number: string | null;
   balance: number;
   is_locked: boolean;
   role: 'member' | 'reseller';
@@ -52,7 +53,7 @@ const UserManagementTable = ({ users, isLoading, onUserAction, onSearch }: UserM
     <div className="border rounded-lg">
       <div className="p-4 flex gap-2">
         <Input
-          placeholder="Cari username..."
+          placeholder="Cari User"
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -23,6 +23,7 @@ interface UserData {
   id: number;
   username: string;
   email: string;
+  phone_number?: string | null;
   balance: number;
   is_locked: boolean;
   role: 'member' | 'reseller';


### PR DESCRIPTION
This PR enhances the Admin User Management feature by allowing administrators to search users by their WhatsApp (phone) number, alongside existing username and email search capabilities.

**Changes:**
- **Backend**: Modified `backend/routes/admin.js` to return `phone_number` in the `GET /users` response. Updated the search SQL query to match `username` and `email` with `LIKE`, and `phone_number` with an exact match.
- **Frontend**:
  - Updated `UserData` types in `src/services/adminService.ts`, `src/components/UserManagementTable.tsx`, and `src/components/UserActionModal.tsx`.
  - Changed the input placeholder in `UserManagementTable` from "Cari username..." to "Cari User".
  - Added the user's phone number to the information section of the `UserActionModal`, complete with a standard Lucide `Phone` icon. Displays `-` if the number is null.

---
*PR created automatically by Jules for task [1815901148642326773](https://jules.google.com/task/1815901148642326773) started by @KedaiVPN*