### PR TITLE
Fix Total Transactions Counter on Landing Page

### DIFF
--- a/backend/routes/publicStats.js
+++ b/backend/routes/publicStats.js
@@ -5,8 +5,8 @@ const pool = require('../db/connection');
 // Get total transaction count for landing page
 router.get('/total-transactions', async (req, res) => {
   try {
-    const [rows] = await pool.query("SELECT COUNT(*) as total FROM balance_transactions WHERE reference_type != 'trial'");
-    const total = rows[0].total;
+    const [rows] = await pool.query("SELECT SUM(total_transaksi) as total FROM users");
+    const total = rows[0].total || 0;
 
     res.json({ success: true, totalTransactions: total });
   } catch (error) {


### PR DESCRIPTION
Fixes the "Total Transaksi" counter on the landing page (About page) from decreasing when transaction history is cleared by switching the count to sum the `total_transaksi` column from the `users` table.

---
*PR created automatically by Jules for task [13634774291796540850](https://jules.google.com/task/13634774291796540850) started by @KedaiVPN*