### PR TITLE
Parse Total Transactions to Number for Correct Formatting

### DIFF
--- a/backend/routes/publicStats.js
+++ b/backend/routes/publicStats.js
@@ -6,7 +6,7 @@ const pool = require('../db/connection');
 router.get('/total-transactions', async (req, res) => {
   try {
     const [rows] = await pool.query("SELECT SUM(total_transaksi) as total FROM users");
-    const total = rows[0].total || 0;
+    const total = parseInt(rows[0].total) || 0;
 
     res.json({ success: true, totalTransactions: total });
   } catch (error) {


### PR DESCRIPTION
Parses the `total` result from the database query to an integer using `parseInt()` so that the frontend's `toLocaleString('id-ID')` can format the number properly with thousands separators (e.g., 56.419).

---
*PR created automatically by Jules for task [13634774291796540850](https://jules.google.com/task/13634774291796540850) started by @KedaiVPN*